### PR TITLE
fix for IOS-4792

### DIFF
--- a/Code/Controllers/ATLConversationViewController.m
+++ b/Code/Controllers/ATLConversationViewController.m
@@ -1256,6 +1256,7 @@ static NSInteger const ATLPhotoActionSheet = 1000;
 {
     NSArray *objectChanges = [self.objectChanges copy];
     [self.objectChanges removeAllObjects];
+    [self.conversationDataSource updateMessages];
     
     if (self.collectionView.window == nil) {
         [self.collectionView reloadData];
@@ -1283,7 +1284,6 @@ static NSInteger const ATLPhotoActionSheet = 1000;
     if (self.collectionView) {
         dispatch_suspend(self.animationQueue);
         [self.collectionView performBatchUpdates:^{
-            [self.conversationDataSource updateMessages];
             for (ATLDataSourceChange *change in objectChanges) {
                 switch (change.type) {
                     case LYRQueryControllerChangeTypeInsert:


### PR DESCRIPTION
objectChanges affects how many sections we will remove/delete during the collection view update. updateMessages, on the other hand, affects how many sections there are after the update.
In the old code, it is possible that there are new message come between the time we get objectChanges and the time we updateMessages. If that happens, a crash will occur because the number of collection view sections is not consistent.